### PR TITLE
Update useAnonymousLogin hook 

### DIFF
--- a/src/components/Firebase/auth.js
+++ b/src/components/Firebase/auth.js
@@ -7,14 +7,16 @@ function useAnonymousLogin() {
   const [token, setToken] = useState();
 
   useEffect(() => {
-    firebase
-      .auth()
-      .signInAnonymously()
-      .catch(console.error);
+    if (!firebase.auth().currentUser) {
+      firebase.auth().signInAnonymously().catch(console.error);
+    } else {
+      setUser(firebase.auth().currentUser);
+      setToken(firebase.auth().currentUser.getIdToken());
+    }
   }, []);
 
   useEffect(() => {
-    firebase.auth().onAuthStateChanged(function(user) {
+    firebase.auth().onAuthStateChanged(function (user) {
       if (!user) {
         setUser(null);
         setToken(null);
@@ -33,7 +35,7 @@ function useAnonymousLogin() {
 
   return {
     user,
-    token
+    token,
   };
 }
 


### PR DESCRIPTION
 No longer logs in again if we already have a user set.

Old behaviour would log an admin user in again as an anonymous user if we went from the admin page to either the articles or search pages, reducing their priviliege unduely.

New behaviour keeps the current user if there one exists.